### PR TITLE
fix - card color not view in list_card_page deck

### DIFF
--- a/pokecard/lib/deck/pages/deck_list_card_page.dart
+++ b/pokecard/lib/deck/pages/deck_list_card_page.dart
@@ -73,7 +73,7 @@ class DeckListCardsPage extends ConsumerWidget {
             },
             child: Container(
               decoration: BoxDecoration(
-                color: Colors.grey.withOpacity(0.2),
+                color: cardColor.withOpacity(0.2),
                 borderRadius: BorderRadius.circular(10),
                 border: Border.all(color: Colors.black, width: 2),
               ),
@@ -119,7 +119,7 @@ class DeckListCardsPage extends ConsumerWidget {
                   ),
                   Positioned(
                     top: 8,
-                    right: 8, 
+                    right: 8,
                     child: _deleteCardButton(context, ref, deckId, index, card),
                   )
                 ],


### PR DESCRIPTION
Este Pr visa resolver o seguinte bug:

**Problema:** Na página "Listagem de cards de um deck" não aparece a cor dos card de acordo com os Pokémon, está uma cor padrão para todos os cards.

**Causa:**  Na linha 76 não estava sendo configurado a cor do item card e sim uma cor default qualquer.

**Solução:** Foi configurado para ser utilizado a cor vinda do item card.


**Validação Local Realizada:** 

https://github.com/user-attachments/assets/e07c50d9-aa9e-40d4-b32b-6f5247e5878c


